### PR TITLE
Allow caller to specify clojure.tools.nrepl.server/start-server options

### DIFF
--- a/src/luminus/repl_server.clj
+++ b/src/luminus/repl_server.clj
@@ -1,8 +1,6 @@
 (ns luminus.repl-server
   (:require [clojure.tools.nrepl.server :as nrepl]
-            [clojure.tools.logging :as log]
-            [mount.core :refer [defstate]]            
-            [environ.core :refer [env]]))
+            [clojure.tools.logging :as log]))
 
 (defonce nrepl-server (atom nil))
 
@@ -13,13 +11,16 @@
     (log/info "nREPL server stopped")))
 
 (defn start
-  "Start a network repl for debugging when the :nrepl-port is set in the environment."
-  [port]
+  "Start a network repl for debugging on specified port.
+  :bind, :transport-fn, :handler, :ack-port and :greeting-fn will be forwarded to clojure.tools.nrepl.server/start-server as they are."
+  [port & {:keys [bind transport-fn handler ack-port greeting-fn]}]
   (if @nrepl-server
     (log/error "nREPL is already running!")
     (try
-        (reset! nrepl-server (nrepl/start-server :port port))
-        (log/info "nREPL server started on port" port)
-        (catch Throwable t
-          (log/error t "failed to start nREPL")))))
-
+      (reset! nrepl-server (nrepl/start-server :port port :bind bind
+                                               :transport-fn transport-fn
+                                               :handler handler :ack-port ack-port
+                                               :greeting-fn greeting-fn))
+      (log/info "nREPL server started on port" port)
+      (catch Throwable t
+        (log/error t "failed to start nREPL")))))


### PR DESCRIPTION
- deletes absent (and not needed) requires.
- changes function comment. Things around environment and thus
  :nrepl-port are not included in this piece of code.
- adds possibility to provide options to
  clojure.tools.nrepl.server/start-server. e.g. Those who use Emacs & CIDER
  need this possibility to fill nrepl server with middleware which
  allows full functionality of IDE when it must be connected to a
  running, embedded server. This changes allow user to do things like:

``` clojure
(defn cider&cljr-nrepl-handler []
      (apply nrepl/default-handler (cons #'refactor-nrepl.middleware/wrap-refactor
                                          (map resolve cider-middleware))))
...
(defn start-app
  "e.g. lein run 3000"
  [[port]]
  (let [port (http-port port)]
    (.addShutdownHook (Runtime/getRuntime) (Thread. stop-app))
    (when-let [repl-port (env :nrepl-port)]
      (repl/start (parse-port repl-port) :handler (cider&cljr-nrepl-handler)))
    (http/start {:handler app
                 :init    init
                 :port    port})))
```
