### PR TITLE
upgrade nrepl to the latest version 0.5.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [nrepl "0.4.4"]
+                 [nrepl "0.5.3"]
                  [org.clojure/tools.logging "0.4.1"]])

--- a/src/luminus/repl_server.clj
+++ b/src/luminus/repl_server.clj
@@ -1,5 +1,5 @@
 (ns luminus.repl-server
-  (:require [clojure.tools.nrepl.server :as nrepl]
+  (:require [nrepl.server :as nrepl]
             [clojure.tools.logging :as log]))
 
 (defn start
@@ -24,4 +24,3 @@
 (defn stop [server]
   (nrepl/stop-server server)
   (log/info "nREPL server stopped"))
-


### PR DESCRIPTION
bumped nrepl version to 0.5.3 and changed the namespace to the new `nrepl.server`